### PR TITLE
[WIP] Adding support for Q&A Agents and environments

### DIFF
--- a/examples/QA_Env/qa_agent.py
+++ b/examples/QA_Env/qa_agent.py
@@ -1,0 +1,108 @@
+from qa_env import QAEnv
+import os
+from tqdm import trange
+import wandb
+from typing import Union
+import math, sys
+from transformers import AutoTokenizer
+from peft import LoraConfig
+from trl import AutoModelForCausalLMWithValueHead
+import re, json
+import gymnasium as gym
+from llamagym import Agent
+
+
+#WIP
+class QAAgent(Agent):
+    def get_system_prompt(self):
+        return "You are a helpful AI assistant that answers questions based on the provided context."
+
+    def format_observation(self, question):
+        return f"Question: {question}\n"
+
+    def extract_action(self, response):
+        return response.strip()
+    
+
+if __name__ == "__main__":
+    hyperparams = {
+        "model_name": "meta-llama/Llama-2-7b-chat-hf",
+        "lora/r": 16,
+        "lora/lora_alpha": 32,
+        "lora/lora_dropout": 0.05,
+        "lora/bias": "none",
+        "lora/task_type": "CAUSAL_LM",
+        "load_in_8bit": True,
+        "batch_size": 8,
+        "seed": 42069,
+        "episodes": 5000,
+        "generate/max_new_tokens": 32,
+        "generate/do_sample": True,
+        "generate/top_p": 0.6,
+        "generate/top_k": 0,
+        "generate/temperature": 0.9,
+    }
+
+wandb_run = wandb.init(project=os.environ.get("WANDB_PROJECT"), config=hyperparams)
+device = "cuda:0"
+HF_TOKEN = os.environ.get("HF_TOKEN")
+
+lora_config = LoraConfig(
+    **{
+        key.split("/")[-1]: value
+        for key, value in hyperparams.items()
+        if key.startswith("lora/")
+    }
+)
+model = AutoModelForCausalLMWithValueHead.from_pretrained(
+    pretrained_model_name_or_path=hyperparams["model_name"],
+    peft_config=lora_config,
+    load_in_8bit=hyperparams["load_in_8bit"],
+    token=HF_TOKEN,
+    device_map='auto'
+)
+tokenizer = AutoTokenizer.from_pretrained(hyperparams["model_name"], token=HF_TOKEN)
+tokenizer.add_special_tokens({"pad_token": "<pad>"})
+model.pretrained_model.resize_token_embeddings(len(tokenizer))
+
+
+
+agent = QAAgent(
+    model,
+    tokenizer,
+    device,
+    {
+        key: value
+        for key, value in hyperparams.items()
+        if key.startswith("generate/")
+    },
+    {
+        "batch_size": hyperparams["batch_size"],
+        "mini_batch_size": hyperparams["batch_size"],
+    },
+)
+
+# Training loop
+env = QAEnv()
+for episode in trange(hyperparams["episodes"]):
+    observation, info = env.reset()
+
+    done = False
+
+    while not done:
+        action = agent.act(observation)
+        wandb.log({"action": action})
+        print(action)
+        observation, reward, terminated, truncated, info = env.step(action)
+        agent.assign_reward(reward)
+        done = terminated
+
+    episode_stats = {
+        "episode": episode,
+        "total_return": sum(agent.current_episode_rewards),
+        "message_ct": len(agent.current_episode_messages),
+        "episode_messages": agent.current_episode_messages,
+    }
+    train_stats = agent.terminate_episode()
+    episode_stats.update(train_stats)
+    wandb.log(episode_stats)

--- a/examples/QA_Env/qa_agent.py
+++ b/examples/QA_Env/qa_agent.py
@@ -26,17 +26,17 @@ class QAAgent(Agent):
 
 if __name__ == "__main__":
     hyperparams = {
-        "model_name": "meta-llama/Llama-2-7b-chat-hf",
+        "model_name": "KingNish/Reasoning-Llama-3b-v0.2",
         "lora/r": 16,
         "lora/lora_alpha": 32,
         "lora/lora_dropout": 0.05,
         "lora/bias": "none",
         "lora/task_type": "CAUSAL_LM",
         "load_in_8bit": True,
-        "batch_size": 8,
+        "batch_size": 1,
         "seed": 42069,
         "episodes": 5000,
-        "generate/max_new_tokens": 32,
+        "generate/max_new_tokens": 100,
         "generate/do_sample": True,
         "generate/top_p": 0.6,
         "generate/top_k": 0,
@@ -86,16 +86,13 @@ agent = QAAgent(
 env = QAEnv()
 for episode in trange(hyperparams["episodes"]):
     observation, info = env.reset()
+    action = agent.act(observation)
+    wandb.log({"action": action})
 
-    done = False
+    observation, reward, terminated, truncated, info = env.step(action)
+    agent.assign_reward(reward)
+    print(agent.current_episode_messages)
 
-    while not done:
-        action = agent.act(observation)
-        wandb.log({"action": action})
-        print(action)
-        observation, reward, terminated, truncated, info = env.step(action)
-        agent.assign_reward(reward)
-        done = terminated
 
     episode_stats = {
         "episode": episode,

--- a/examples/QA_Env/qa_env.py
+++ b/examples/QA_Env/qa_env.py
@@ -1,0 +1,40 @@
+import random
+import gymnasium as gym
+from gymnasium.spaces import Discrete, Dict, Box, Text
+from llamagym import evaluate_state
+from datasets import load_dataset
+
+
+
+class QAEnv(gym.Env):
+    def __init__(self):
+        super(QAEnv, self).__init__()
+        self.observation_space = Dict({
+            'question': Text(max_length=500),
+            'context': Text(max_length=500)
+        })
+        self.dataset = load_dataset('microsoft/orca-math-word-problems-200k')
+        self.current_episode_rewards = []
+        self.current_episode_messages = []
+
+    def reset(self):
+        choice = random.randint(0, len(self.dataset['train']) - 1)
+        question, answer = self.dataset['train'][choice]['question'],  self.dataset['train'][choice]['answer']
+        self.goal_state = answer
+        return question, {}
+
+    def step(self, action):
+        agent_state = action[0]
+        task = self.goal_state
+
+        data = evaluate_state(task, agent_state, self.goal_state)
+        reward = data['reward']
+        info = data['feedback']
+        
+        print(f"Reward: {reward}")
+        print(info, "green")
+
+        done = data.get('reached_goal',False)
+
+        return self.observation_space.sample(), reward, done,"", info
+

--- a/examples/QA_Env/qa_env.py
+++ b/examples/QA_Env/qa_env.py
@@ -1,10 +1,17 @@
 import random
+import sys
 import gymnasium as gym
 from gymnasium.spaces import Discrete, Dict, Box, Text
 from llamagym import evaluate_state
 from datasets import load_dataset
 
-
+def printc(obj, color="cyan"):
+    color_code = {
+        "black": "30", "red": "31", "green": "32", "yellow": "33",
+        "blue": "34", "magenta": "35", "cyan": "36", "white": "37"
+    }
+    colored_text = f"\033[{color_code[color]}m{obj}\033[0m" if color in color_code else obj
+    print(colored_text)
 
 class QAEnv(gym.Env):
     def __init__(self):
@@ -13,28 +20,31 @@ class QAEnv(gym.Env):
             'question': Text(max_length=500),
             'context': Text(max_length=500)
         })
-        self.dataset = load_dataset('microsoft/orca-math-word-problems-200k')
+        self.dataset = load_dataset('danikhan632/OpenMystery')
         self.current_episode_rewards = []
         self.current_episode_messages = []
 
     def reset(self):
         choice = random.randint(0, len(self.dataset['train']) - 1)
-        question, answer = self.dataset['train'][choice]['question'],  self.dataset['train'][choice]['answer']
+        question, answer = self.dataset['train'][choice]['start_state'],  self.dataset['train'][choice]['solution']
         self.goal_state = answer
         return question, {}
 
     def step(self, action):
-        agent_state = action[0]
-        task = self.goal_state
 
+        task = self.goal_state
+        
+        agent_state = f"Reasoning:\n {action[1]['content']}\nAssistant:\n {action[2]['content']}"
+        
         data = evaluate_state(task, agent_state, self.goal_state)
+        printc(data,'yellow')
+        
         reward = data['reward']
         info = data['feedback']
         
         print(f"Reward: {reward}")
-        print(info, "green")
+        printc(info, "green")
 
-        done = data.get('reached_goal',False)
 
-        return self.observation_space.sample(), reward, done,"", info
+        return self.observation_space.sample(), reward, True,"", info
 

--- a/examples/detective/main.py
+++ b/examples/detective/main.py
@@ -1,0 +1,319 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import get_peft_model, LoraConfig, TaskType
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import Dataset, DataLoader
+from transformers import get_linear_schedule_with_warmup
+import numpy as np
+import random
+import sys
+from datasets import load_dataset
+import os
+from openai import OpenAI
+import json
+
+
+os.system('clear')
+
+def printc(obj, color="cyan"):
+    color_code = {
+        "black": "30", "red": "31", "green": "32", "yellow": "33",
+        "blue": "34", "magenta": "35", "cyan": "36", "white": "37"
+    }
+    colored_text = f"\033[{color_code[color]}m{obj}\033[0m" if color in color_code else obj
+    print(colored_text)
+
+def evaluate_state(data_entry, model="gpt-4o-mini"):
+    client = OpenAI() 
+    msgs = [
+        {
+            "role": "system",
+            "content": """
+                    You are a helpful AI assistant that helps evaluate an agent at problem solving.
+                    Given a question and a final goal state, evaluate the agent's Chain of Thought.
+                    You should provide a score from 100 to -100 with 100 being an extremely logical
+                    reasoning step in the path to the goal state and -100 being an extremely illogical reasoning step 
+                    on the path to the goal state. 
+                    be reasonable with your scores.
+            """,
+        },
+        {
+            "role": "user",
+            "content": str(
+                "QUESTION/START STATE: "
+                + str(data_entry.get("question", ""))
+                + "\nAGENT CHAIN OF THOUGHT: "
+                + str(data_entry.get("steps", ""))
+                + "\nCORRECT GOAL STATE: "
+                + str(data_entry.get("final_answer", ""))
+            )
+        },
+    ]
+    
+    response = client.chat.completions.create(
+        model=model,
+        messages=msgs,
+        functions=[
+            {
+                "name": "eval_chain_of_thought",
+                "description": "function to score each Thought in chain of thought",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "chain_of_thought": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "thought_id": { "type": "string" },
+                                    "thought_score": {
+                                        "type": "integer", 
+                                        "description": "the score from 100 to -100"
+                                    }
+                                },
+                                "required": ["thought_id", "thought_score"]
+                            },
+                            "description": "A list of dictionaries with string keys and integer values."
+                        }
+                    }
+                },
+            }
+        ],
+    )
+
+    data = json.loads(response.choices[0].message.function_call.arguments)
+    
+    thought_scores = data['chain_of_thought']
+    score_dict = {score['thought_id']: score['thought_score'] for score in thought_scores}
+    
+    # Enrich the steps with their scores
+    enriched_steps = []
+    for i, step in enumerate(data_entry['steps']):
+        thought_id = f"thought_{i}"  # Align with zero-based indexing
+        score = score_dict.get(thought_id, 0)  # Default score to 0 if not found
+
+        enriched_steps.append({
+            "id": thought_id,
+            "txt": step[f'thought_{i}'],
+            "score": score / 100
+        })
+    
+    combined_data = {
+        "question": data_entry["question"],
+        "steps": enriched_steps,
+        "final_answer": data_entry["final_answer"]
+    }
+
+    return combined_data
+
+class OnlineRewardDataset(Dataset):
+    def __init__(self, questions, model, tokenizer, num_samples=100, max_length=512):
+        self.questions = questions
+        self.model = model
+        self.tokenizer = tokenizer
+        self.num_samples = num_samples
+        self.max_length = max_length
+
+    def __len__(self):
+        return self.num_samples
+
+    def __getitem__(self, idx):
+        # Randomly select a question
+        question_data = random.choice(self.questions)
+        user_question = "Solve this mystery below:\n" + question_data['start_state']
+        correct_answer = question_data['solution']
+        
+        # Generate reasoning response
+        messages = [
+            {"role": "system", "content": "You are a helpful crime fighting detective"}, 
+            {"role": "user", "content": user_question}
+        ]
+        prompt = self.tokenizer.apply_chat_template(messages, tokenize=False, add_reasoning_prompt=True)
+  
+        
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.model.device)
+        with torch.no_grad():
+            outputs = self.model.generate(
+                **inputs,
+                max_new_tokens=600,
+            )
+        
+        reasoning_response = self.tokenizer.decode(outputs[0, inputs.input_ids.shape[1]:], skip_special_tokens=True).split("\n\n")
+
+        # Generate progressively expanding subsets of reasoning
+        cumulative_reasons = []
+        for i in range(len(reasoning_response)):
+            cumulative_reasons.append({f"thought_{i}": reasoning_response[i]})
+            
+        data = {'steps':cumulative_reasons, 'question':user_question, 'final_answer':correct_answer}
+        results = evaluate_state(data)
+
+        examples = []
+        total_string=""
+        for idx_step, step in enumerate(results['steps']):
+            total_string += "\n\n" + step['txt']
+            # Prepare input for each reasoning step
+            msgs = [
+                {'role':"user", 'content':results['question']},
+                {'role':'reasoning','content':total_string}
+            ]
+
+            step_prompt = self.tokenizer.apply_chat_template(msgs, tokenize=False)
+            encoded = self.tokenizer(
+                step_prompt,
+                max_length=self.max_length,
+                padding='max_length',
+                truncation=True,
+                return_tensors='pt'
+            )
+
+            # Store user_question, reasoning_response (at this step), and correct_answer for debugging
+            examples.append({
+                'input_ids': encoded['input_ids'][0],
+                'attention_mask': encoded['attention_mask'][0],
+                'reward': torch.tensor(step['score'], dtype=torch.float),
+                'user_question': results['question'],
+                'reasoning_response': total_string,
+                'correct_answer': correct_answer
+            })
+
+        # Return list of examples for this item
+        return examples
+
+def custom_collate_fn(batch):
+    # batch is a list of lists (each item from __getitem__ returns multiple examples)
+    # Flatten this list
+    flat_examples = [ex for ex_list in batch for ex in ex_list]
+
+    input_ids = torch.stack([ex['input_ids'] for ex in flat_examples], dim=0)
+    attention_mask = torch.stack([ex['attention_mask'] for ex in flat_examples], dim=0)
+    reward = torch.stack([ex['reward'] for ex in flat_examples], dim=0)
+
+    user_question = [ex['user_question'] for ex in flat_examples]
+    reasoning_response = [ex['reasoning_response'] for ex in flat_examples]
+    correct_answer = [ex['correct_answer'] for ex in flat_examples]
+
+    return {
+        'input_ids': input_ids,
+        'attention_mask': attention_mask,
+        'reward': reward,
+        'user_question': user_question,
+        'reasoning_response': reasoning_response,
+        'correct_answer': correct_answer
+    }
+
+def prepare_model(model_name, device="auto"):
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype="auto",
+        device_map=device,
+        load_in_8bit=True
+    )
+    
+    lora_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        target_modules=["q_proj", "v_proj"],
+        lora_dropout=0.05,
+        bias="none",
+        task_type=TaskType.CAUSAL_LM
+    )
+    
+    model = get_peft_model(model, lora_config)
+    return model
+
+def train_model(model, tokenizer, questions, 
+                num_epochs=25,
+                samples_per_epoch=10,
+                batch_size=1,
+                learning_rate=2e-5,
+                max_grad_norm=1.0,
+                warmup_steps=100,
+                gradient_accumulation_steps=4):
+    
+    dataset = OnlineRewardDataset(questions, model, tokenizer, num_samples=samples_per_epoch)
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True, collate_fn=custom_collate_fn)
+    
+    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)
+    total_steps = len(dataloader) * num_epochs
+    scheduler = get_linear_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=warmup_steps,
+        num_training_steps=total_steps
+    )
+    
+    device = next(model.parameters()).device
+    model.train()
+    
+    for epoch in range(num_epochs):
+        total_loss = 0
+        optimizer.zero_grad()
+        
+        for batch_idx, batch in enumerate(dataloader):
+  
+            input_ids = batch['input_ids'].to(device)
+            attention_mask = batch['attention_mask'].to(device)
+            rewards = batch['reward'].to(device)
+            
+            outputs = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                labels=input_ids
+            )
+            
+            base_loss = outputs.loss
+            reward_tensor = rewards.view(-1, 1, 1).expand_as(outputs.logits)
+            loss = base_loss * (1 + reward_tensor)
+            loss = loss.mean() / gradient_accumulation_steps
+            
+            loss.backward()
+            
+            if (batch_idx + 1) % gradient_accumulation_steps == 0:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)
+                optimizer.step()
+                scheduler.step()
+                optimizer.zero_grad()
+            
+            total_loss += loss.item() * gradient_accumulation_steps
+            
+            # Print example from batch
+            if batch_idx % 10 == 0:
+                print("\nExample interaction:")
+                print(f"Q: {batch['user_question'][0]}")
+                print(f"A: {batch['reasoning_response'][0]}")
+                print(f"Correct (unused): {batch['correct_answer'][0]}")
+                print(f"Reward: {batch['reward'][0].item():.3f}")
+        
+        avg_loss = total_loss / len(dataloader)
+        print(f"\nEpoch {epoch+1}/{num_epochs}, Average Loss: {avg_loss:.4f}")
+        
+        reward_mean = rewards.mean().item()
+        reward_std = rewards.std().item()
+        print(f"Reward stats - Mean: {reward_mean:.4f}, Std: {reward_std:.4f}")
+    
+    return model
+
+def main():
+    model_name = "KingNish/Reasoning-Llama-3b-v0.2"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+    model = prepare_model(model_name)
+    
+
+    questions = load_dataset("danikhan632/OpenMystery")['train']
+    trained_model = train_model(
+        model, 
+        tokenizer, 
+        questions,
+        samples_per_epoch=1,  # fewer samples for demo
+        batch_size=1,
+        gradient_accumulation_steps=1
+    )
+    
+    trained_model.save_pretrained("online_trained_reward_model_lora")
+
+if __name__ == "__main__":
+    main()

--- a/llamagym/__init__.py
+++ b/llamagym/__init__.py
@@ -1,1 +1,2 @@
 from .agent import Agent
+from .llm_eval import evaluate_state

--- a/llamagym/llm_eval.py
+++ b/llamagym/llm_eval.py
@@ -1,0 +1,74 @@
+
+
+from openai import OpenAI
+import json
+
+
+def evaluate_state(agent_state:str,question:str, goal_state:str, model="gpt-3.5-turbo-0125", base_url:str=None):
+    client = OpenAI() if base_url is None else OpenAI(base_url=base_url)
+    score = 0
+    response = client.chat.completions.create(
+        model=model,
+        max_tokens=120,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a helpful AI assistant that helps evuluate an agent at problem solving. Given a question and a goal state, evaluate the agent's current state",
+            },
+            {
+                "role": "user",
+                "content": str(
+                    "QUESTION/START STATE:"
+                    + question
+                    + "\nAGENT CURRENT STATE: "
+                    + agent_state
+                    + "\n:CORRECT GOAL STATE: "
+                    + goal_state
+                ),
+            },
+        ],
+        functions=[
+            {
+                "name": "evaluate_state",
+                "description": "Evaluates the agent's answer compared to the answer key",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "warmer_colder": {
+                            "type": "string",
+                            "enum":[ "hot", "warmer", "colder", "same", "cold"],
+                            "description": "is the agent's current state closer or further from the goal state",
+                        },
+                        "feedback": {
+                            "type": "string",
+                            "description": "in a few short words, provide feedback to the agent on their answer",
+                        },
+                        "reached_goal": {
+                            "type": "boolean",
+                            "description": "true if the agent's current state the goal state, otherwise false",
+                        },
+
+                    },
+                },
+            }
+        ],
+    )
+
+    
+    data = json.loads(response.choices[0].message.function_call.arguments)
+    
+    #these are just sample metrics
+    score += 1000 if data.get("reached_goal", False) else 0
+    score += 100 if data.get("warmer_colder") == "hot" and not data.get("reached_goal", False) else 0
+    score += 50 if data.get("warmer_colder") == "warmer" and not data.get("reached_goal", False) else 0
+    # No need for a line for "same" as it does not change the score
+    score -= 50 if data.get("warmer_colder") == "colder" and not data.get("reached_goal", False) else 0
+    score -= 100 if data.get("warmer_colder") == "cold" and not data.get("reached_goal", False) else 0
+    score -= 200 if data.get("is_nonsense", False) else 0
+
+    feedback = data.get("feedback","No feedback")
+
+    return {'reward': score, 'feedback': feedback, 'done':data.get("reached_goal", False)}
+
+
+

--- a/llamagym/llm_eval.py
+++ b/llamagym/llm_eval.py
@@ -13,7 +13,7 @@ def evaluate_state(agent_state:str,question:str, goal_state:str, model="gpt-3.5-
         messages=[
             {
                 "role": "system",
-                "content": "You are a helpful AI assistant that helps evuluate an agent at problem solving. Given a question and a goal state, evaluate the agent's current state",
+                "content": "You are a helpful AI assistant that helps evuluate an agent at problem solving. Given a question and a goal state, evaluate the agent's current state and reasoning steps based on the rubric/solution",
             },
             {
                 "role": "user",
@@ -34,18 +34,13 @@ def evaluate_state(agent_state:str,question:str, goal_state:str, model="gpt-3.5-
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "warmer_colder": {
-                            "type": "string",
-                            "enum":[ "hot", "warmer", "colder", "same", "cold"],
-                            "description": "is the agent's current state closer or further from the goal state",
-                        },
                         "feedback": {
                             "type": "string",
                             "description": "in a few short words, provide feedback to the agent on their answer",
                         },
-                        "reached_goal": {
-                            "type": "boolean",
-                            "description": "true if the agent's current state the goal state, otherwise false",
+                        "score": {
+                            "type": "number",
+                            "description": "the score of based on the rubric",
                         },
 
                     },
@@ -58,17 +53,11 @@ def evaluate_state(agent_state:str,question:str, goal_state:str, model="gpt-3.5-
     data = json.loads(response.choices[0].message.function_call.arguments)
     
     #these are just sample metrics
-    score += 1000 if data.get("reached_goal", False) else 0
-    score += 100 if data.get("warmer_colder") == "hot" and not data.get("reached_goal", False) else 0
-    score += 50 if data.get("warmer_colder") == "warmer" and not data.get("reached_goal", False) else 0
-    # No need for a line for "same" as it does not change the score
-    score -= 50 if data.get("warmer_colder") == "colder" and not data.get("reached_goal", False) else 0
-    score -= 100 if data.get("warmer_colder") == "cold" and not data.get("reached_goal", False) else 0
-    score -= 200 if data.get("is_nonsense", False) else 0
+    score += data.get("score", 0) 
 
     feedback = data.get("feedback","No feedback")
 
-    return {'reward': score, 'feedback': feedback, 'done':data.get("reached_goal", False)}
+    return {'reward': score, 'feedback': feedback}
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ bitsandbytes = "^0.40.0"
 textworld = "^1.6.1"
 scipy = "^1.12.0"
 wandb = "^0.16.4"
-
+openai="^1.0.0"
+datasets="^2.1.0"
 
 [tool.poetry.group.dev.dependencies]
 wandb = "^0.16.2"

--- a/utils/critic-server/readme.md
+++ b/utils/critic-server/readme.md
@@ -1,0 +1,1 @@
+This is for the QA environment and will serve as LLM grader, in order to use it, server.py must be run and your base_url needs to be passed into evaluate_state. Using OpenAI is default behavior but if you have a seperate powerful PC, this server could be used instead of OAI API

--- a/utils/critic-server/reponse_format.gbnf
+++ b/utils/critic-server/reponse_format.gbnf
@@ -1,0 +1,12 @@
+root ::= "{" warmerColder "," reachedGoal "," feedback "}"
+
+warmerColder ::= "\"warmer_colder\":" ws "\"" warmerColderEnum "\""
+warmerColderEnum ::= "hot" | "warmer" | "colder" | "same" | "cold"
+
+reachedGoal ::= "\"reached_goal\":" ws boolean
+boolean ::= "true" | "false"
+
+feedback ::= "\"feedback\":" ws string
+string ::= "\"" ( [^"\\\x7F\x00-\x1F] | "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) )* "\"" ws
+
+ws ::= ([ \t\n\r]*)

--- a/utils/critic-server/sample_client.py
+++ b/utils/critic-server/sample_client.py
@@ -1,0 +1,16 @@
+from openai import OpenAI
+from llamagym import evaluate_state
+
+
+
+question="You are a detective investigating a warehouse that has burned down, it may have been arson, find out the culprint"
+agent_state= "I will investigate how many sprinkles are on the average donut"
+goal_state="The owners did it for an insurance payout"
+
+# an obvious sanity check
+
+oai_resp = evaluate_state(agent_state,question ,goal_state)
+print(oai_resp)
+
+cpp_res = evaluate_state(agent_state,question ,goal_state, base_url="http://127.0.0.1:8000/v1")
+print(cpp_res)

--- a/utils/critic-server/server.py
+++ b/utils/critic-server/server.py
@@ -1,0 +1,83 @@
+
+import threading
+import uvicorn
+import asyncio
+from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.requests import Request
+from fastapi.responses import JSONResponse
+from sse_starlette import EventSourceResponse
+import os, json, datetime, re, time
+from utils import printc, ChatCompletionRequest, to_dict
+from llama_cpp import Llama, LlamaGrammar
+
+
+from datetime import datetime
+
+llm = Llama("./llama2-70b.gguf", n_gpu_layers=-1, n_ctx=16384)
+
+
+streaming_semaphore = asyncio.Semaphore(1)
+
+
+app = FastAPI()
+
+password ="password"
+def verify_api_key(authorization: str = Header(None)) -> None:
+    expected_api_key = password
+    if expected_api_key and (authorization is None or authorization != f"Bearer {expected_api_key}"):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+# check_key = [Depends(verify_api_key)]
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+# Mutex lock
+data_lock = threading.Lock()
+
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to the FastAPI server!"}
+
+@app.post('/v1/chat/completions')
+async def openai_chat_completions(request: Request, request_data: ChatCompletionRequest):
+    with data_lock:
+        printc("Request Received","red")
+        request_data= to_dict(request_data)
+        printc(request_data,"yellow")
+        msgs=request_data['messages']
+        msgs[-1]['content']+=""" \n
+        please respond in the following format:
+            warmer_colder= whether the agent getting warmer/closer or colder/further away from the goal state. 
+            answer warmer_colder by using one of the options: "hot", "warmer", "colder", "same", "cold"
+
+            feedback= this is feedback to agent that should not give away the answer but should provivde constructive
+            critism. Note that your are given the final goal state above so you should base your feedback on that. PROVIDE AT LEAST 5 WORDS OF FEEDBACK
+        
+            reached_goal= this either true or false if the agent has actually solved the problem and their state matches the goal state
+
+        """
+        res = llm.create_chat_completion(messages=msgs,
+                                         temperature=request_data['temperature'],
+                                         grammar=LlamaGrammar.from_file('reponse_format.gbnf'))
+
+        output=json.loads(res['choices'][0]['message']["content"])
+        output['feedback'] = output['feedback'].replace("\n", " ").replace('\r', '').replace("<|im_end|>", "").replace("<|im_start|>","").replace("assistant","").strip()
+        res['choices'][0]['message']["content"]=None
+        res['model']=request_data['model']
+        res['choices'][0]['message']["function_call"]={"name":request_data["functions"][0]['name'],"arguments":json.dumps(output) }
+        printc(res['choices'][0]['message']["function_call"],"green")
+
+        return res
+
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/utils/critic-server/utils.py
+++ b/utils/critic-server/utils.py
@@ -1,0 +1,91 @@
+import json
+import time
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+def printc(obj, color="cyan"):
+    color_code = {
+        "black": "30", "red": "31", "green": "32", "yellow": "33",
+        "blue": "34", "magenta": "35", "cyan": "36", "white": "37"
+    }
+    colored_text = f"\033[{color_code[color]}m{obj}\033[0m" if color in color_code else obj
+    print(colored_text)
+
+class ChatCompletionRequestParams(BaseModel):
+    messages: List[dict]
+    model: str | None = Field(default=None, description="Unused parameter. To change the model, use the /v1/internal/model/load endpoint.")
+    frequency_penalty: float | None = 0
+    function_call: str | dict | None = Field(default=None, description="Unused parameter.")
+    functions: List[dict] | None = Field(default=None, description="Unused parameter.")
+    logit_bias: dict | None = None
+    max_tokens: int | None = None
+    n: int | None = Field(default=1, description="Unused parameter.")
+    presence_penalty: float | None = 0
+    stop: str | List[str] | None = None
+    stream: bool | None = False
+    temperature: float | None = 1
+    top_p: float | None = 1
+    user: str | None = Field(default=None, description="Unused parameter.")
+
+    mode: str = Field(default='instruct', description="Valid options: instruct, chat, chat-instruct.")
+
+    instruction_template: str | None = Field(default=None, description="An instruction template defined under text-generation-webui/instruction-templates. If not set, the correct template will be automatically obtained from the model metadata.")
+    instruction_template_str: str | None = Field(default=None, description="A Jinja2 instruction template. If set, will take precedence over everything else.")
+
+    character: str | None = Field(default=None, description="A character defined under text-generation-webui/characters. If not set, the default \"Assistant\" character will be used.")
+    name1: str | None = Field(default=None, description="Your name (the user). By default, it's \"You\".")
+    name2: str | None = Field(default=None, description="Overwrites the value set by character.")
+    context: str | None = Field(default=None, description="Overwrites the value set by character.")
+    greeting: str | None = Field(default=None, description="Overwrites the value set by character.")
+    chat_template_str: str | None = Field(default=None, description="Jinja2 template for chat.")
+
+    chat_instruct_command: str | None = None
+
+    continue_: bool = Field(default=False, description="Makes the last bot message in the history be continued instead of starting a new message.")
+
+class GenerationOptions(BaseModel):
+    preset: str | None = Field(default=None, description="The name of a file under text-generation-webui/presets (without the .yaml extension). The sampling parameters that get overwritten by this option are the keys in the default_preset() function in modules/presets.py.")
+    min_p: float = 0
+    top_k: int = 0
+    repetition_penalty: float = 1
+    repetition_penalty_range: int = 1024
+    typical_p: float = 1
+    tfs: float = 1
+    top_a: float = 0
+    epsilon_cutoff: float = 0
+    eta_cutoff: float = 0
+    guidance_scale: float = 1
+    negative_prompt: str = ''
+    penalty_alpha: float = 0
+    mirostat_mode: int = 0
+    mirostat_tau: float = 5
+    mirostat_eta: float = 0.1
+    temperature_last: bool = False
+    do_sample: bool = True
+    seed: int = -1
+    encoder_repetition_penalty: float = 1
+    no_repeat_ngram_size: int = 0
+    min_length: int = 0
+    num_beams: int = 1
+    length_penalty: float = 1
+    early_stopping: bool = False
+    truncation_length: int = 0
+    max_tokens_second: int = 0
+    custom_token_bans: str = ""
+    auto_max_new_tokens: bool = False
+    ban_eos_token: bool = False
+    add_bos_token: bool = True
+    skip_special_tokens: bool = True
+    grammar_string: str = ""
+
+
+class ChatCompletionRequest(GenerationOptions, ChatCompletionRequestParams):
+    pass
+
+
+
+
+def to_dict(obj):
+    return obj.__dict__
+


### PR DESCRIPTION
Motivation for this:
I want the ability to finetune LLMs on more than just a discrete action space such as Blackjack or other games with a discrete action space. So a few additions were made. 

- llm_eval.py: since the actions space is basically just text, we need an actual reward system. I've seen similar implementations to this using keyword however I settled on using another (larger)LLM , giving it the task, agent's current state and the goal state and asking it whether the agent is getting closer to the goal state and feedback to the agent. OpenAI function calling/gbnf is used to create structured JSON to generate a numeric reward for a given state
- critic_server: this is a llama.cpp server to fill the role as previously mentioned. It uses llama grammars to reliably generate JSON similar to fuction calling. Would recommend using a Larger Model to be the critic. This whole thing is fully optional though and by default OAI API will be used.
-(WIP)  QA Agent & Env: this is agent that will use the llm_eval, its given question from orca-math 200k and asked to solve them

In Progress things:
Also working on the ability from transformer lib LLMs to produce structured JSON similar to llama.cpp. For example, someone could make a strategy game and a gym env and the agent could reliablity place a JSON format to play they game without having to resorting to truncating outputs and all that


Would love to get feed back on all of this